### PR TITLE
Integrate NatureOS frontend components

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NATUREOS_API_URL=https://natureos-api.mycosoft.com
+NATUREOS_API_KEY=your-api-key-here
+NEXT_PUBLIC_MYCA_ENABLED=true
+NEXT_PUBLIC_LIVE_DATA_ENABLED=true

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,0 +1,129 @@
+// Next.js API route for Mycosoft website dashboard integration
+// This should be placed in the Mycosoft website repository
+
+import { NextResponse } from 'next/server';
+
+// NatureOS API configuration
+const NATUREOS_API_BASE = process.env.NATUREOS_API_URL || 'https://natureos-api.mycosoft.com';
+const API_KEY = process.env.NATUREOS_API_KEY;
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const dataType = searchParams.get('type') || 'all';
+
+    // Fetch data from NatureOS Core API
+    const response = await fetch(`${NATUREOS_API_BASE}/api/mycosoft/website/dashboard`, {
+      headers: {
+        'Authorization': `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`NatureOS API error: ${response.status}`);
+    }
+
+    const dashboardData = await response.json();
+
+    // Transform data for website components
+    const transformedData = {
+      stats: {
+        totalEvents: dashboardData.totalEvents,
+        activeDevices: dashboardData.activeDevices,
+        speciesDetected: dashboardData.speciesDetected,
+        onlineUsers: dashboardData.onlineUsers,
+      },
+      liveData: {
+        readings: dashboardData.liveReadings.map(reading => ({
+          device: reading.deviceId,
+          value: reading.value,
+          timestamp: reading.timestamp,
+          status: 'active',
+        })),
+        lastUpdate: new Date().toISOString(),
+      },
+      insights: {
+        trendingCompounds: dashboardData.trendingCompounds,
+        recentDiscoveries: dashboardData.recentDiscoveries,
+      },
+      networkHealth: {
+        status: 'optimal',
+        connections: dashboardData.activeDevices,
+        throughput: '2.4 MB/s',
+      },
+    };
+
+    return NextResponse.json(transformedData);
+  } catch (error) {
+    console.error('Dashboard API error:', error);
+    
+    // Return fallback data if NatureOS is unavailable
+    return NextResponse.json({
+      stats: {
+        totalEvents: 150000,
+        activeDevices: 42,
+        speciesDetected: 156,
+        onlineUsers: 23,
+      },
+      liveData: {
+        readings: [
+          { device: 'MUSHROOM-001', value: 23.5, timestamp: new Date().toISOString(), status: 'active' },
+          { device: 'SPORE-DET-002', value: 0.75, timestamp: new Date().toISOString(), status: 'active' },
+          { device: 'ENV-STATION-A', value: 78.2, timestamp: new Date().toISOString(), status: 'active' },
+        ],
+        lastUpdate: new Date().toISOString(),
+      },
+      insights: {
+        trendingCompounds: ['Psilocybin', 'Cordycepin', 'Beta-glucan'],
+        recentDiscoveries: [
+          'New mycorrhizal network topology discovered',
+          'Novel antifungal compound isolated',
+        ],
+      },
+      networkHealth: {
+        status: 'optimal',
+        connections: 42,
+        throughput: '2.4 MB/s',
+      },
+      error: error.message,
+    }, { status: 200 }); // Return 200 with fallback data
+  }
+}
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { action, data } = body;
+
+    switch (action) {
+      case 'sync':
+        // Trigger data sync
+        const syncResponse = await fetch(`${NATUREOS_API_BASE}/api/mycosoft/sync`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${API_KEY}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            syncTargets: ['website'],
+            dataTypes: ['events', 'devices', 'species'],
+          }),
+        });
+
+        const syncResult = await syncResponse.json();
+        return NextResponse.json(syncResult);
+
+      case 'update':
+        // Handle dashboard updates from NatureOS
+        // This would update the website's local cache
+        return NextResponse.json({ success: true, message: 'Dashboard updated' });
+
+      default:
+        return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+    }
+  } catch (error) {
+    console.error('Dashboard POST error:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+} 

--- a/app/api/myca/route.ts
+++ b/app/api/myca/route.ts
@@ -1,0 +1,227 @@
+// Next.js API route for MYCA AI Assistant integration
+// This should be placed in the Mycosoft website repository
+
+import { NextResponse } from 'next/server';
+
+const NATUREOS_API_BASE = process.env.NATUREOS_API_URL || 'https://natureos-api.mycosoft.com';
+const API_KEY = process.env.NATUREOS_API_KEY;
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { question, context, userId } = body;
+
+    if (!question) {
+      return NextResponse.json({ error: 'Question is required' }, { status: 400 });
+    }
+
+    // Send question to MYCA through NatureOS API
+    const response = await fetch(`${NATUREOS_API_BASE}/api/mycosoft/myca/query`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        question,
+        context,
+        userId,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`MYCA API error: ${response.status}`);
+    }
+
+    const mycaResponse = await response.json();
+
+    // Format response for website
+    const formattedResponse = {
+      answer: mycaResponse.answer,
+      confidence: mycaResponse.confidence,
+      sources: mycaResponse.sources,
+      timestamp: mycaResponse.timestamp,
+      suggestedQuestions: mycaResponse.suggestedQuestions,
+      conversationId: generateConversationId(),
+    };
+
+    return NextResponse.json(formattedResponse);
+  } catch (error) {
+    console.error('MYCA API error:', error);
+    
+    // Return fallback response
+    const fallbackResponse = generateFallbackResponse(body.question);
+    return NextResponse.json(fallbackResponse);
+  }
+}
+
+// WebSocket endpoint for real-time MYCA conversations
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const action = searchParams.get('action');
+
+    switch (action) {
+      case 'suggestions':
+        // Get suggested questions based on current data
+        const suggestions = await getSuggestedQuestions();
+        return NextResponse.json({ suggestions });
+
+      case 'context':
+        // Get current system context for MYCA
+        const context = await getSystemContext();
+        return NextResponse.json({ context });
+
+      default:
+        return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+    }
+  } catch (error) {
+    console.error('MYCA GET error:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+async function getSuggestedQuestions() {
+  try {
+    // Fetch live data to generate contextual suggestions
+    const liveDataResponse = await fetch(`${NATUREOS_API_BASE}/api/mycosoft/website/live-data`, {
+      headers: {
+        'Authorization': `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const liveData = await liveDataResponse.json();
+
+    // Generate suggestions based on current data
+    const suggestions = [
+      'What species are most active right now?',
+      'Show me the mycorrhizal network status',
+      'What compounds are trending today?',
+      'How is the environmental data looking?',
+      'What anomalies have been detected?',
+      'Explain the latest spore dispersal patterns',
+    ];
+
+    // Add dynamic suggestions based on live data
+    if (liveData.environmentalReadings?.length > 0) {
+      const latestTemp = liveData.environmentalReadings.find(r => r.parameter === 'Temperature');
+      if (latestTemp) {
+        suggestions.push(`Why is the temperature ${latestTemp.value}°C?`);
+      }
+    }
+
+    return suggestions.slice(0, 6); // Return top 6 suggestions
+  } catch (error) {
+    // Return default suggestions on error
+    return [
+      'What species are active in the network?',
+      'Show me the latest discoveries',
+      'What is the system health status?',
+      'Explain the mycorrhizal connections',
+    ];
+  }
+}
+
+async function getSystemContext() {
+  try {
+    const response = await fetch(`${NATUREOS_API_BASE}/api/mycosoft/website/live-data`, {
+      headers: {
+        'Authorization': `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const liveData = await response.json();
+
+    return {
+      timestamp: new Date().toISOString(),
+      activeDevices: liveData.networkActivity?.activeConnections || 0,
+      recentActivity: liveData.speciesObservations?.slice(0, 3) || [],
+      systemHealth: liveData.systemHealth?.overallHealth || 'Unknown',
+      environmentalStatus: liveData.environmentalReadings?.[0] || null,
+    };
+  } catch (error) {
+    return {
+      timestamp: new Date().toISOString(),
+      activeDevices: 0,
+      recentActivity: [],
+      systemHealth: 'Unknown',
+      environmentalStatus: null,
+    };
+  }
+}
+
+function generateFallbackResponse(question) {
+  const lowerQuestion = question.toLowerCase();
+  
+  let answer = "I'm currently analyzing data through the NatureOS MINDEX database. ";
+  
+  if (lowerQuestion.includes('species')) {
+    answer += "I can see several active species in the network, including Amanita muscaria and Pleurotus ostreatus. Would you like more details about a specific species?";
+  } else if (lowerQuestion.includes('network') || lowerQuestion.includes('connection')) {
+    answer += "The mycorrhizal network is showing healthy interconnectivity with multiple active nodes. The clustering coefficient is approximately 0.73.";
+  } else if (lowerQuestion.includes('compound') || lowerQuestion.includes('chemical')) {
+    answer += "Current trending bioactive compounds include Psilocybin, Cordycepin, and Beta-glucan. I'm detecting increased synthesis activity.";
+  } else if (lowerQuestion.includes('health') || lowerQuestion.includes('status')) {
+    answer += "System health is optimal with 42 active devices and normal environmental parameters. All sensors are reporting within expected ranges.";
+  } else {
+    answer += "Could you be more specific about what aspect of the fungal intelligence network you'd like to explore?";
+  }
+
+  return {
+    answer,
+    confidence: 0.7,
+    sources: ['MINDEX Fallback', 'Local Cache'],
+    timestamp: new Date().toISOString(),
+    suggestedQuestions: [
+      'What species are active in the network?',
+      'Show me the mycorrhizal connections',
+      'What compounds are being produced?',
+      'How is the system health?',
+    ],
+    conversationId: generateConversationId(),
+    fallback: true,
+  };
+}
+
+function generateConversationId() {
+  return `conv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+// Streaming endpoint for real-time MYCA responses
+export async function PUT(request) {
+  const body = await request.json();
+  const { action, conversationId, feedback } = body;
+
+  try {
+    switch (action) {
+      case 'feedback':
+        // Send feedback to MYCA for learning
+        await fetch(`${NATUREOS_API_BASE}/api/mycosoft/myca/feedback`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${API_KEY}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            conversationId,
+            feedback,
+            timestamp: new Date().toISOString(),
+          }),
+        });
+
+        return NextResponse.json({ success: true, message: 'Feedback recorded' });
+
+      case 'continue':
+        // Continue conversation with follow-up
+        return NextResponse.json({ success: true, message: 'Conversation continued' });
+
+      default:
+        return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+    }
+  } catch (error) {
+    console.error('MYCA PUT error:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+} 

--- a/app/myca-ai/page.tsx
+++ b/app/myca-ai/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { Chat } from "@/components/chat/chat"
+import MycaChatComponent from "@/components/natureos/MycaChatComponent"
 
 export const metadata: Metadata = {
   title: "Myca AI - Mycosoft",
@@ -10,7 +10,7 @@ export default function MycaAIPage() {
   return (
     <div className="container flex h-[calc(100vh-4rem)] flex-col py-6">
       <h1 className="text-3xl font-bold mb-8">Myca AI Assistant</h1>
-      <Chat />
+      <MycaChatComponent />
     </div>
   )
 }

--- a/app/natureos/page.tsx
+++ b/app/natureos/page.tsx
@@ -8,6 +8,7 @@ import { Cloud, Code, Database, FileText, Gauge, Globe, PipetteIcon, Settings } 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { DashboardShell } from "@/components/dashboard/shell"
+import LiveDataComponent from "@/components/natureos/LiveDataComponent"
 
 const appWidgets = [
   {
@@ -120,6 +121,12 @@ export default function NatureOSPage() {
               </Link>
             ))}
           </div>
+        </section>
+
+        {/* Live Data */}
+        <section>
+          <h2 className="text-2xl font-bold mb-4">Live Data</h2>
+          <LiveDataComponent />
         </section>
       </div>
     </DashboardShell>

--- a/components/natureos/LiveDataComponent.tsx
+++ b/components/natureos/LiveDataComponent.tsx
@@ -1,0 +1,240 @@
+// React component for live data integration with NatureOS
+// This should be placed in the Mycosoft website repository
+
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function LiveDataComponent() {
+  const [liveData, setLiveData] = useState(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [lastUpdate, setLastUpdate] = useState(null);
+  const [error, setError] = useState(null);
+
+  // Fetch live data from NatureOS
+  const fetchLiveData = useCallback(async () => {
+    try {
+      const response = await fetch('/api/dashboard?type=live');
+      if (!response.ok) throw new Error('Failed to fetch data');
+      
+      const data = await response.json();
+      setLiveData(data);
+      setLastUpdate(new Date());
+      setIsConnected(true);
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+      setIsConnected(false);
+    }
+  }, []);
+
+  // Set up real-time updates
+  useEffect(() => {
+    fetchLiveData();
+    const interval = setInterval(fetchLiveData, 5000); // Update every 5 seconds
+    return () => clearInterval(interval);
+  }, [fetchLiveData]);
+
+  if (!liveData) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <motion.div
+          animate={{ rotate: 360 }}
+          transition={{ duration: 2, repeat: Infinity, ease: "linear" }}
+          className="w-8 h-8 border-2 border-green-500 border-t-transparent rounded-full"
+        />
+        <span className="ml-3 text-gray-600">Connecting to NatureOS...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Connection Status */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <motion.div
+            animate={{ scale: isConnected ? [1, 1.2, 1] : 1 }}
+            transition={{ duration: 1, repeat: isConnected ? Infinity : 0 }}
+            className={`w-3 h-3 rounded-full ${
+              isConnected ? 'bg-green-500' : 'bg-red-500'
+            }`}
+          />
+          <span className="text-sm text-gray-600">
+            {isConnected ? 'Connected to NatureOS' : 'Disconnected'}
+          </span>
+        </div>
+        {lastUpdate && (
+          <span className="text-xs text-gray-500">
+            Last update: {lastUpdate.toLocaleTimeString()}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-700 text-sm">⚠️ {error}</p>
+        </div>
+      )}
+
+      {/* System Stats */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatCard
+          title="Active Devices"
+          value={liveData.stats?.activeDevices || 0}
+          change="+2"
+          icon="📡"
+        />
+        <StatCard
+          title="Species Detected"
+          value={liveData.stats?.speciesDetected || 0}
+          change="+1"
+          icon="🍄"
+        />
+        <StatCard
+          title="Total Events"
+          value={liveData.stats?.totalEvents || 0}
+          change="+150"
+          icon="📊"
+        />
+        <StatCard
+          title="Online Users"
+          value={liveData.stats?.onlineUsers || 0}
+          change="+5"
+          icon="👥"
+        />
+      </div>
+
+      {/* Live Readings */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          🌡️ Live Environmental Readings
+        </h3>
+        <div className="space-y-3">
+          <AnimatePresence>
+            {liveData.liveData?.readings?.map((reading, index) => (
+              <motion.div
+                key={reading.device}
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: 20 }}
+                transition={{ delay: index * 0.1 }}
+                className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+              >
+                <div className="flex items-center space-x-3">
+                  <div className={`w-2 h-2 rounded-full ${
+                    reading.status === 'active' ? 'bg-green-500' : 'bg-gray-400'
+                  }`} />
+                  <span className="font-medium text-gray-700">{reading.device}</span>
+                </div>
+                <div className="text-right">
+                  <div className="font-semibold text-gray-900">{reading.value}</div>
+                  <div className="text-xs text-gray-500">
+                    {new Date(reading.timestamp).toLocaleTimeString()}
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {/* Network Health */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          🔗 Network Health
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600">
+              {liveData.networkHealth?.status || 'Unknown'}
+            </div>
+            <div className="text-sm text-gray-600">Status</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-blue-600">
+              {liveData.networkHealth?.connections || 0}
+            </div>
+            <div className="text-sm text-gray-600">Connections</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-purple-600">
+              {liveData.networkHealth?.throughput || '0 MB/s'}
+            </div>
+            <div className="text-sm text-gray-600">Throughput</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Trending Insights */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          🔬 Trending Insights
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h4 className="font-medium text-gray-700 mb-2">Trending Compounds</h4>
+            <ul className="space-y-1">
+              {liveData.insights?.trendingCompounds?.map((compound, index) => (
+                <motion.li
+                  key={compound}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.1 }}
+                  className="text-sm text-gray-600 flex items-center space-x-2"
+                >
+                  <span className="w-2 h-2 bg-green-500 rounded-full" />
+                  <span>{compound}</span>
+                </motion.li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="font-medium text-gray-700 mb-2">Recent Discoveries</h4>
+            <ul className="space-y-1">
+              {liveData.insights?.recentDiscoveries?.map((discovery, index) => (
+                <motion.li
+                  key={discovery}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.1 }}
+                  className="text-sm text-gray-600"
+                >
+                  • {discovery}
+                </motion.li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ title, value, change, icon }) {
+  return (
+    <motion.div
+      whileHover={{ scale: 1.02 }}
+      className="bg-white rounded-lg border border-gray-200 p-4"
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-600">{title}</p>
+          <motion.p
+            key={value}
+            initial={{ scale: 1.1 }}
+            animate={{ scale: 1 }}
+            className="text-2xl font-bold text-gray-900"
+          >
+            {typeof value === 'number' ? value.toLocaleString() : value}
+          </motion.p>
+          {change && (
+            <p className="text-xs text-green-600 font-medium">{change}</p>
+          )}
+        </div>
+        <div className="text-2xl">{icon}</div>
+      </div>
+    </motion.div>
+  );
+} 

--- a/components/natureos/MycaChatComponent.tsx
+++ b/components/natureos/MycaChatComponent.tsx
@@ -1,0 +1,303 @@
+// MYCA AI Assistant chat component for Mycosoft website
+// This integrates with NatureOS through the MYCA API
+
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function MycaChatComponent() {
+  const [messages, setMessages] = useState([
+    {
+      id: 1,
+      type: 'assistant',
+      content: "Hello! I'm MYCA, your fungal intelligence assistant. I'm connected to the NatureOS MINDEX database and can help you explore the mycological network. What would you like to know?",
+      timestamp: new Date(),
+    }
+  ]);
+  const [input, setInput] = useState('');
+  const [isTyping, setIsTyping] = useState(false);
+  const [suggestions, setSuggestions] = useState([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const messagesEndRef = useRef(null);
+
+  // Load suggested questions on mount
+  useEffect(() => {
+    loadSuggestions();
+    checkConnection();
+  }, []);
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const loadSuggestions = async () => {
+    try {
+      const response = await fetch('/api/myca?action=suggestions');
+      const data = await response.json();
+      setSuggestions(data.suggestions || []);
+    } catch (error) {
+      console.error('Failed to load suggestions:', error);
+      setSuggestions([
+        'What species are active in the network?',
+        'Show me the latest discoveries',
+        'How is the system health?',
+        'Explain the mycorrhizal connections',
+      ]);
+    }
+  };
+
+  const checkConnection = async () => {
+    try {
+      const response = await fetch('/api/myca?action=context');
+      setIsConnected(response.ok);
+    } catch (error) {
+      setIsConnected(false);
+    }
+  };
+
+  const sendMessage = async (messageText = input) => {
+    if (!messageText.trim()) return;
+
+    const userMessage = {
+      id: Date.now(),
+      type: 'user',
+      content: messageText.trim(),
+      timestamp: new Date(),
+    };
+
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+    setIsTyping(true);
+
+    try {
+      const response = await fetch('/api/myca', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          question: messageText.trim(),
+          context: 'website-chat',
+          userId: 'web-user',
+        }),
+      });
+
+      const data = await response.json();
+
+      const assistantMessage = {
+        id: Date.now() + 1,
+        type: 'assistant',
+        content: data.answer,
+        confidence: data.confidence,
+        sources: data.sources,
+        suggestedQuestions: data.suggestedQuestions,
+        timestamp: new Date(),
+        fallback: data.fallback,
+      };
+
+      setMessages(prev => [...prev, assistantMessage]);
+      
+      // Update suggestions with new ones from response
+      if (data.suggestedQuestions) {
+        setSuggestions(data.suggestedQuestions);
+      }
+    } catch (error) {
+      const errorMessage = {
+        id: Date.now() + 1,
+        type: 'assistant',
+        content: "I'm having trouble connecting to the NatureOS network right now. Please try again in a moment.",
+        timestamp: new Date(),
+        error: true,
+      };
+      setMessages(prev => [...prev, errorMessage]);
+    }
+
+    setIsTyping(false);
+  };
+
+  const handleKeyPress = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  };
+
+  const sendFeedback = async (messageId, feedbackType) => {
+    try {
+      await fetch('/api/myca', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'feedback',
+          conversationId: `msg_${messageId}`,
+          feedback: { type: feedbackType, messageId },
+        }),
+      });
+    } catch (error) {
+      console.error('Failed to send feedback:', error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-96 bg-white rounded-lg border border-gray-200 shadow-sm">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b border-gray-200">
+        <div className="flex items-center space-x-3">
+          <div className="w-8 h-8 bg-gradient-to-r from-green-500 to-blue-500 rounded-full flex items-center justify-center">
+            <span className="text-white font-bold text-sm">🧠</span>
+          </div>
+          <div>
+            <h3 className="font-semibold text-gray-900">MYCA AI Assistant</h3>
+            <div className="flex items-center space-x-2">
+              <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500'}`} />
+              <span className="text-xs text-gray-500">
+                {isConnected ? 'Connected to NatureOS' : 'Offline'}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        <AnimatePresence>
+          {messages.map((message) => (
+            <motion.div
+              key={message.id}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className={`flex ${message.type === 'user' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div className={`max-w-xs lg:max-w-md px-4 py-2 rounded-lg ${
+                message.type === 'user'
+                  ? 'bg-blue-500 text-white'
+                  : message.error
+                  ? 'bg-red-50 text-red-700 border border-red-200'
+                  : 'bg-gray-100 text-gray-900'
+              }`}>
+                <p className="text-sm">{message.content}</p>
+                
+                {/* Assistant message metadata */}
+                {message.type === 'assistant' && !message.error && (
+                  <div className="mt-2 space-y-2">
+                    {message.confidence && (
+                      <div className="text-xs text-gray-500">
+                        Confidence: {Math.round(message.confidence * 100)}%
+                        {message.fallback && ' (Fallback mode)'}
+                      </div>
+                    )}
+                    
+                    {message.sources && (
+                      <div className="text-xs text-gray-500">
+                        Sources: {message.sources.join(', ')}
+                      </div>
+                    )}
+
+                    {/* Feedback buttons */}
+                    <div className="flex space-x-2">
+                      <button
+                        onClick={() => sendFeedback(message.id, 'helpful')}
+                        className="text-xs text-green-600 hover:text-green-700"
+                        title="This was helpful"
+                      >
+                        👍
+                      </button>
+                      <button
+                        onClick={() => sendFeedback(message.id, 'not-helpful')}
+                        className="text-xs text-red-600 hover:text-red-700"
+                        title="This wasn't helpful"
+                      >
+                        👎
+                      </button>
+                    </div>
+                  </div>
+                )}
+                
+                <div className="text-xs opacity-75 mt-1">
+                  {message.timestamp.toLocaleTimeString()}
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </AnimatePresence>
+
+        {/* Typing indicator */}
+        {isTyping && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            className="flex justify-start"
+          >
+            <div className="bg-gray-100 rounded-lg px-4 py-2">
+              <div className="flex space-x-1">
+                <motion.div
+                  animate={{ scale: [1, 1.2, 1] }}
+                  transition={{ duration: 0.6, repeat: Infinity, delay: 0 }}
+                  className="w-2 h-2 bg-gray-400 rounded-full"
+                />
+                <motion.div
+                  animate={{ scale: [1, 1.2, 1] }}
+                  transition={{ duration: 0.6, repeat: Infinity, delay: 0.2 }}
+                  className="w-2 h-2 bg-gray-400 rounded-full"
+                />
+                <motion.div
+                  animate={{ scale: [1, 1.2, 1] }}
+                  transition={{ duration: 0.6, repeat: Infinity, delay: 0.4 }}
+                  className="w-2 h-2 bg-gray-400 rounded-full"
+                />
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Suggested Questions */}
+      {suggestions.length > 0 && (
+        <div className="p-4 border-t border-gray-200">
+          <p className="text-xs text-gray-500 mb-2">Suggested questions:</p>
+          <div className="flex flex-wrap gap-2">
+            {suggestions.slice(0, 3).map((suggestion, index) => (
+              <motion.button
+                key={suggestion}
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: index * 0.1 }}
+                onClick={() => sendMessage(suggestion)}
+                className="px-3 py-1 text-xs bg-gray-100 hover:bg-gray-200 rounded-full text-gray-700 transition-colors"
+              >
+                {suggestion}
+              </motion.button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Input */}
+      <div className="p-4 border-t border-gray-200">
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyPress={handleKeyPress}
+            placeholder="Ask MYCA about the fungal network..."
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+            disabled={isTyping}
+          />
+          <motion.button
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
+            onClick={() => sendMessage()}
+            disabled={isTyping || !input.trim()}
+            className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed text-sm font-medium"
+          >
+            Send
+          </motion.button>
+        </div>
+      </div>
+    </div>
+  );
+} 


### PR DESCRIPTION
## Summary
- add Next.js API routes for NatureOS dashboard and MYCA
- include LiveData and MycaChat components from NatureOS
- expose environment variables via `.env.example`
- show MYCA chat and live data on website pages
- allow `.env.example` to be committed

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875cacf007c832a9f139ce2c43bb01c