### PR TITLE
Enable SSE-based live dashboard updates

### DIFF
--- a/app/api/dashboard/stream/route.ts
+++ b/app/api/dashboard/stream/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from 'next/server';
+
+const NATUREOS_API_BASE = process.env.NATUREOS_API_URL || 'https://natureos-api.mycosoft.com';
+const API_KEY = process.env.NATUREOS_API_KEY;
+
+// Helper to transform dashboard payload into shape expected by website components
+async function fetchDashboardData() {
+  const response = await fetch(`${NATUREOS_API_BASE}/api/mycosoft/website/dashboard`, {
+    headers: {
+      'Authorization': `Bearer ${API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`NatureOS API error: ${response.status}`);
+  }
+
+  const dashboardData = await response.json();
+
+  return {
+    stats: {
+      totalEvents: dashboardData.totalEvents,
+      activeDevices: dashboardData.activeDevices,
+      speciesDetected: dashboardData.speciesDetected,
+      onlineUsers: dashboardData.onlineUsers,
+    },
+    liveData: {
+      readings: dashboardData.liveReadings.map((reading: any) => ({
+        device: reading.deviceId,
+        value: reading.value,
+        timestamp: reading.timestamp,
+        status: 'active',
+      })),
+      lastUpdate: new Date().toISOString(),
+    },
+    insights: {
+      trendingCompounds: dashboardData.trendingCompounds,
+      recentDiscoveries: dashboardData.recentDiscoveries,
+    },
+    networkHealth: {
+      status: 'optimal',
+      connections: dashboardData.activeDevices,
+      throughput: '2.4 MB/s',
+    },
+  };
+}
+
+export async function GET(_request: NextRequest) {
+  const encoder = new TextEncoder();
+
+  let interval: NodeJS.Timeout;
+  const stream = new ReadableStream({
+    async start(controller) {
+      async function pushUpdate() {
+        try {
+          const data = await fetchDashboardData();
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+        } catch (err: any) {
+          controller.enqueue(encoder.encode(`event: error\ndata: ${err.message}\n\n`));
+        }
+      }
+
+      // Send initial update immediately
+      await pushUpdate();
+
+      interval = setInterval(pushUpdate, 5000);
+    },
+    cancel() {
+      if (interval) clearInterval(interval);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/components/natureos/LiveDataComponent.tsx
+++ b/components/natureos/LiveDataComponent.tsx
@@ -3,7 +3,7 @@
 
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
 export default function LiveDataComponent() {
@@ -12,29 +12,31 @@ export default function LiveDataComponent() {
   const [lastUpdate, setLastUpdate] = useState(null);
   const [error, setError] = useState(null);
 
-  // Fetch live data from NatureOS
-  const fetchLiveData = useCallback(async () => {
-    try {
-      const response = await fetch('/api/dashboard?type=live');
-      if (!response.ok) throw new Error('Failed to fetch data');
-      
-      const data = await response.json();
-      setLiveData(data);
-      setLastUpdate(new Date());
-      setIsConnected(true);
-      setError(null);
-    } catch (err) {
-      setError(err.message);
-      setIsConnected(false);
-    }
-  }, []);
-
-  // Set up real-time updates
+  // Set up real-time updates via Server-Sent Events
   useEffect(() => {
-    fetchLiveData();
-    const interval = setInterval(fetchLiveData, 5000); // Update every 5 seconds
-    return () => clearInterval(interval);
-  }, [fetchLiveData]);
+    const evtSource = new EventSource('/api/dashboard/stream');
+
+    evtSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setLiveData(data);
+        setLastUpdate(new Date());
+        setIsConnected(true);
+        setError(null);
+      } catch (err) {
+        setError('Failed to parse update');
+      }
+    };
+
+    evtSource.onerror = () => {
+      setIsConnected(false);
+      setError('Connection lost');
+    };
+
+    return () => {
+      evtSource.close();
+    };
+  }, []);
 
   if (!liveData) {
     return (


### PR DESCRIPTION
## Summary
- replace polling logic in `LiveDataComponent` with an EventSource that consumes server-sent events
- add `/api/dashboard/stream` SSE endpoint that periodically forwards NatureOS dashboard data

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689654f2989c832abe4424bf8bee8bd1