### PR TITLE
Require CHEMSPIDER_API_KEY (remove fallback) and add security review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NATUREOS_API_URL=https://natureos-api.mycosoft.com
 NATUREOS_API_KEY=your-api-key-here
+CHEMSPIDER_API_KEY=your-api-key-here
 NEXT_PUBLIC_MYCA_ENABLED=true
 NEXT_PUBLIC_LIVE_DATA_ENABLED=true

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,17 @@
+# Security Review Notes
+
+## Scope
+- Working tree scan for potential secrets (excluded `node_modules`).
+- Git history scan across all commits for common secret patterns.
+
+## Commands run
+- `rg -n -S "(API_KEY|SECRET|TOKEN|PASSWORD|BEGIN RSA|BEGIN PRIVATE|AWS_|GCP_|AZURE_|ssh-rsa|PRIVATE KEY|SECRET_KEY|SLACK|WEBHOOK|ENCRYPTION|CREDENTIAL|BEARER)" --glob '!node_modules/**' --glob '!.pnpm/**' .`
+- `git rev-list --all | xargs -n 50 git grep -n -I -e "temp-mock-chemspider-key-123456789" -e "BEGIN PRIVATE KEY" -e "AKIA" -e "ssh-rsa" -e "NATUREOS_API_KEY" -e "MONGODB_API_KEY" -e "AZURE_MAPS_KEY"`
+
+## Findings
+- The working tree referenced environment variables for API keys but did not include real secrets.
+- Git history contained a hardcoded placeholder ChemSpider key string in `lib/services/chemical-data.ts`.
+
+## Recommended follow-ups
+- Rotate any credentials that may have been exposed historically.
+- Rewrite Git history to remove the placeholder key string if you intend to fully scrub public history.

--- a/lib/services/chemical-data.ts
+++ b/lib/services/chemical-data.ts
@@ -1,7 +1,7 @@
 import { getWikipediaImage } from "./wikipedia"
 import { SPECIES_MAPPING } from "./species-mapping"
 
-const CHEMSPIDER_API_KEY = process.env.CHEMSPIDER_API_KEY || "temp-mock-chemspider-key-123456789"
+const CHEMSPIDER_API_KEY = process.env.CHEMSPIDER_API_KEY
 
 interface ChemSpiderCompound {
   id: string
@@ -206,6 +206,9 @@ export async function getCompoundDetails(id: string): Promise<ChemSpiderCompound
 
     // Try ChemSpider API
     if (id.startsWith("CS")) {
+      if (!CHEMSPIDER_API_KEY) {
+        throw new Error("Missing CHEMSPIDER_API_KEY for ChemSpider requests")
+      }
       const csId = id.replace("CS", "")
       const response = await fetch(`https://api.rsc.org/compounds/v1/records/${csId}`, {
         headers: {


### PR DESCRIPTION
### Motivation
- Remove an embedded placeholder API key to prevent accidental use or leakage of a hardcoded ChemSpider key.
- Ensure runtime behavior fails fast when the required `CHEMSPIDER_API_KEY` is not configured.
- Provide an example environment variable for developers to configure locally.
- Record the repository secret-scan steps and findings for follow-up remediation.

### Description
- Removed the hardcoded fallback key and read `CHEMSPIDER_API_KEY` only from `process.env` in `lib/services/chemical-data.ts` and added a runtime guard that throws when the key is missing.
- Added `CHEMSPIDER_API_KEY=your-api-key-here` to `.env.example` to document the required configuration.
- Added `SECURITY_REVIEW.md` that lists the scan commands run, findings (historic placeholder key present in history), and recommended follow-ups to fully scrub history and rotate secrets.

### Testing
- Ran an automated repository scan with `rg -n -S "(API_KEY|SECRET|TOKEN|PASSWORD|BEGIN RSA|BEGIN PRIVATE|AWS_|GCP_|AZURE_|ssh-rsa|PRIVATE KEY|SECRET_KEY|SLACK|WEBHOOK|ENCRYPTION|CREDENTIAL|BEARER)" --glob '!node_modules/**' --glob '!.pnpm/**' .` which completed and helped locate relevant entries in the working tree.
- Ran an automated history inspection with `git rev-list --all | xargs -n 50 git grep -n -I -e "temp-mock-chemspider-key-123456789" -e "BEGIN PRIVATE KEY" -e "AKIA" -e "ssh-rsa" -e "NATUREOS_API_KEY" -e "MONGODB_API_KEY" -e "AZURE_MAPS_KEY"` which completed and confirmed the placeholder ChemSpider key existed in past commits.
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff402a5c0832a863df7d2ce6d2071)